### PR TITLE
Remove setuptools dependence - Add python versions to conda

### DIFF
--- a/fstpy/__init__.py
+++ b/fstpy/__init__.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
-import pkg_resources
+import sys
+if sys.version_info < (3, 9):
+    import importlib_resources as resources
+else:
+    import importlib.resources as resources
 import sys
 from pathlib import Path
 from threading import RLock, stack_size
@@ -140,21 +144,24 @@ KIND_DICT = {
 :meta hide-value:
 """
 
-def _get_csv_path(filename):
-  try:
-      csv_path = pkg_resources.resource_filename('fstpy', f'csv/{filename}')
-  except KeyError:
-      csv_path = None
-  return csv_path
+def _read_csv(filename, **kwargs):
+    # try:
+    #     csv_path = pkg_resources.resource_filename('fstpy', f'csv/{filename}')
+    # except KeyError:
+    #     csv_path = None
+    csv_dir = resources.files('fstpy.csv')
+    try:
+        with resources.as_file(csv_dir / filename) as f:
+            return pd.read_csv(f, **kwargs)
+    except FileNotFoundError as err:
+        return None
 
-_csv_path = _get_csv_path
 
+_stationsfb = _read_csv('stationsfb.csv')
+_vctypes = _read_csv('verticalcoordinatetypes.csv')
+_unitcorrespondance = _read_csv('unitcorrespondance.csv')
 
-_stationsfb = pd.read_csv(_csv_path('stationsfb.csv'))
-_vctypes = pd.read_csv(_csv_path('verticalcoordinatetypes.csv'))
-_unitcorrespondance = pd.read_csv(_csv_path('unitcorrespondance.csv'))
-
-_units = pd.read_csv(_csv_path('units.csv'), dtype={
+_units = _read_csv('units.csv', dtype={
     'name': str,
     'symbol': str,
     'expression': str,
@@ -169,9 +176,9 @@ _units = pd.read_csv(_csv_path('units.csv'), dtype={
     'luminousIntensity': 'int32'
 })
 
-# _etikets = pd.read_csv(_csv_path + 'etiket.csv')
-_leveltypes = pd.read_csv(_csv_path('leveltype.csv'))
-_thermoconstants = pd.read_csv(_csv_path('thermo_constants.csv'))
+# _etikets = _read_csv + 'etiket.csv')
+_leveltypes = _read_csv('leveltype.csv')
+_thermoconstants = _read_csv('thermo_constants.csv')
 
 STATIONSFB = _stationsfb  # : :meta hide-value:
 """FB stations table

--- a/fstpy/__init__.py
+++ b/fstpy/__init__.py
@@ -145,16 +145,17 @@ KIND_DICT = {
 """
 
 def _read_csv(filename, **kwargs):
-    # try:
-    #     csv_path = pkg_resources.resource_filename('fstpy', f'csv/{filename}')
-    # except KeyError:
-    #     csv_path = None
+    """Read a csv stored as resources of this package.
+
+    Additionnal kwargs are passed to pandas' read_csv.
+    Raises a ValueError is the file is not found.
+    """
     csv_dir = resources.files('fstpy.csv')
     try:
         with resources.as_file(csv_dir / filename) as f:
             return pd.read_csv(f, **kwargs)
     except FileNotFoundError as err:
-        return None
+        raise ValueError(f'File {filename} is not part of the csv resources of fstpy.') from err
 
 
 _stationsfb = _read_csv('stationsfb.csv')

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setuptools.setup(
         "Operating System :: OS Linux",
     ],
     install_requires=[
-        'pandas>=1.2.4','numpy>=1.23.0','dask>=2021.8.0', 'cmcdict >= 2024.07.22'
+        'pandas>=1.2.4','numpy>=1.23.0','dask>=2021.8.0', 'cmcdict >= 2024.07.22',
+        'importlib-resources; python_version<"3.9"',
     ],
     packages=setuptools.find_packages(exclude='test'),
     include_package_data=True,


### PR DESCRIPTION
Salut! 

Petite PR qui modifie 2 choses:

- `importlib.resources`
Sur le supercalculateur qu'utilise Ouranos (Narval), je dois passer par `pip` et non `conda`. Et j'ai eu des bogues au début parce `import pkg_resources` échouait. En fait, ce module est un morceau de  `setuptools` qui n'est pas mentionné dans les dépendances de `fstpy`.  Après quelques recherches, j'ai découvert que ce n'était d'ailleurs plus la version recommandée d'aller chercher des ressources de paquet (depuis python 3.9 je pense). Donc voici une réécriture de l'ouverture des csv qui essaye de suivre la manière recommandée. 

Ça ajoute une dépendance sur `importlib_resources` qui est un back port du module built-in, mais juste pour python < 3.9.

Le "try-except" est là pour que le type d'erreur reste le même si le fichier n'existe pas. Avant, la fonction `csv_path` donnait un None et  `pd.read_csv(None)` provoquait une ValueError.

- Versions Python sur conda
Du côté des serveurs locaux d'Ouranos, j'essaye de suivre la progression de python. Et on est rendu à Python 3.12, voir meme 3.13. Malgré le "noarch: python" dans la recette conda, je ne trouve que des version 3.9, 3.10 et 3.11 sur le canal conda `fortiers`. Je suis pas certain du pourquoi, mais je devine que ça vient de la liste explicite dans la config du build ? J'y ai donc ajouté les deux versions les plus récentes.


Merci!